### PR TITLE
Add basic support for Music Packs and WZSound Patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ presets.txt
 /custom_*.*
 
 custom-music/
+music-packs/
 
 models/*
 !models/README.md

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -110,7 +110,7 @@ DEFAULT_AREA = OrderedDict(
     angle=0,
     area_link=-1,
     unk3=0,
-    dummy=b"\xFF\xFF\xFF",
+    dummy=b"\xff\xff\xff",
 )
 
 DEFAULT_PATH = OrderedDict(
@@ -118,14 +118,14 @@ DEFAULT_PATH = OrderedDict(
     unk2=-1,
     pnt_start_idx=0,
     pnt_total_count=0,
-    unk3=b"\xFF\xFF\xFF\xFF\x00\xFF",
+    unk3=b"\xff\xff\xff\xff\x00\xff",
 )
 
 DEFAULT_PNT = OrderedDict(
     posx=0.0,
     posy=0.0,
     posz=0.0,
-    unk=b"\xFF\xFF\xFF\xFF",
+    unk=b"\xff\xff\xff\xff",
 )
 
 # cutscenes to use to set storyflags, sceneflags and itemflags
@@ -1454,11 +1454,9 @@ class GamePatcher:
             current_loftwing_model_pack_name=self.placement_file.options[
                 "selected-loftwing-model-pack"
             ],
-            current_music_pack=self.placement_file.options[
-                "music_pack"
-            ],
+            current_music_pack=self.placement_file.options["music_pack"],
             copy_unmodified=False,
-            placement_file=placement_file
+            placement_file=placement_file,
         )
         self.text_labels = {}
 

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1458,6 +1458,7 @@ class GamePatcher:
                 "music_pack"
             ],
             copy_unmodified=False,
+            placement_file=placement_file
         )
         self.text_labels = {}
 

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1454,6 +1454,9 @@ class GamePatcher:
             current_loftwing_model_pack_name=self.placement_file.options[
                 "selected-loftwing-model-pack"
             ],
+            current_music_pack=self.placement_file.options[
+                "music_pack"
+            ],
             copy_unmodified=False,
         )
         self.text_labels = {}

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -1334,6 +1334,7 @@ class RandoGUI(QMainWindow):
 
             if ui_name.startswith("label_for_"):
                 ui_name = ui_name[len("label_for_") :]
+                print(ui_name)
 
             option = self.option_map[ui_name]
             self.set_option_description(option["help"])

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -1334,7 +1334,6 @@ class RandoGUI(QMainWindow):
 
             if ui_name.startswith("label_for_"):
                 ui_name = ui_name[len("label_for_") :]
-                print(ui_name)
 
             option = self.option_map[ui_name]
             self.set_option_description(option["help"])

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -308,7 +308,6 @@ class RandoGUI(QMainWindow):
             self.change_model_type
         )
 
-
         # Music Pack Calls
         self.populate_music_pack_dropdown()
         self.ui.option_music_pack.currentIndexChanged.connect(

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -70,6 +70,7 @@ CUSTOM_THEME_PATH = "custom_theme.json"
 
 LINK_MODEL_DATA_PATH = RANDO_ROOT_PATH / "assets" / "default-link-data"
 CUSTOM_MODELS_PATH = Path("models")
+MUSIC_PACK_PATH = RANDO_ROOT_PATH / "music-packs"
 
 # Add stylesheet overrides here.
 BASE_STYLE_SHEET_OVERRIDES = ""
@@ -305,6 +306,13 @@ class RandoGUI(QMainWindow):
 
         self.ui.option_model_type_select.currentIndexChanged.connect(
             self.change_model_type
+        )
+
+
+        # Music Pack Calls
+        self.populate_music_pack_dropdown()
+        self.ui.option_music_pack.currentIndexChanged.connect(
+            self.update_music_pack_setting
         )
 
         self.ui.button_reset_all_colors.clicked.connect(self.reset_all_colors)
@@ -952,6 +960,28 @@ class RandoGUI(QMainWindow):
         if dialog.exec():
             self.enabled_tricks = dialog.getTrickValues()
             self.update_settings()
+
+    # Music Pack Functions
+
+    def populate_music_pack_dropdown(self):
+        self.ui.option_music_pack.addItem("Vanilla")
+        if os.path.exists(MUSIC_PACK_PATH):
+            subfolders = [f.path for f in os.scandir(MUSIC_PACK_PATH) if f.is_dir()]
+            for folder in subfolders:
+                self.ui.option_music_pack.addItem(os.path.basename(folder))
+        else:
+            os.mkdir(MUSIC_PACK_PATH)
+
+        self.ui.option_music_pack.addItem("Random Pack")
+        self.ui.option_music_pack.addItem("Random Songs from Packs")
+        self.ui.option_music_pack.addItem("Don't Patch")
+
+        current_pack = self.options["music_pack"]
+        self.ui.option_music_pack.setCurrentText(current_pack)
+
+    def update_music_pack_setting(self):
+        self.options.set_option("music_pack", self.ui.option_music_pack.currentText())
+        self.save_settings()
 
     # Custom model customisation funcs
 

--- a/options.yaml
+++ b/options.yaml
@@ -637,7 +637,10 @@
   default: Default
   permalink: false
   cosmetic: true
-  help: "Determines what Music Pack will be applied."
+  help: "If enabled, this will apply that music pack's music to your game. Also supports the following options:
+        **Random Pack**: will apply the music of one of your music packs or vanilla music.
+        **Random Songs from Packs**: for a given song, it will apply the music of a random music pack or vanilla music.
+        **Don't Patch**: prevents the program from patching anything to the 'wzs' folder in 'modified-extract."
 - name: Precise Item Hints
   command: precise-item
   type: boolean

--- a/options.yaml
+++ b/options.yaml
@@ -633,17 +633,11 @@
   ui: option_cube_sots
 - name: Music Pack
   command: music_pack
-  type: singlechoice
-  default: Vanilla
-  choices:
-    - Vanilla
-    - Random Pack
-    - Random Songs from Packs
-    - Don't Patch
+  type: string
+  default: Default
   permalink: false
   cosmetic: true
   help: "Determines what Music Pack will be applied."
-  ui: option_music_pack
 - name: Precise Item Hints
   command: precise-item
   type: boolean

--- a/sslib/allpatch.py
+++ b/sslib/allpatch.py
@@ -38,10 +38,18 @@ DEFAULT_MODEL_DATA_PATH = RANDO_ROOT_PATH / "assets" / "default-link-data"
 CUSTOM_MODELS_PATH = Path("models")
 OARC_PATH = Path("oarc")
 
-WZSOUND_ACTUAL_PATH = RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
-WZSOUND_MODIFIED_PATH = RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
-WZS_ACTUAL_PATH = RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "wzs"
-WZS_MODIFIED_PATH = RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "wzs"
+WZSOUND_ACTUAL_PATH = (
+    RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
+)
+WZSOUND_MODIFIED_PATH = (
+    RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
+)
+WZS_ACTUAL_PATH = (
+    RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "wzs"
+)
+WZS_MODIFIED_PATH = (
+    RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "wzs"
+)
 MUSIC_PACK_PATH = RANDO_ROOT_PATH / "music-packs"
 TADTONE_SONG = "F63D5DB51DE748A3729628C659397A49"
 ARC_REPLACEMENTS_PATH = RANDO_ROOT_PATH / "arc-replacements"
@@ -61,7 +69,7 @@ class AllPatcher:
         current_loftwing_model_pack_name: str,
         current_music_pack: str,
         copy_unmodified: bool = True,
-        placement_file: PlacementFile = None
+        placement_file: PlacementFile = None,
     ):
         """
         Creates a new instance of the AllPatcher, which patches the game files but with a single callback for each resource type
@@ -310,7 +318,9 @@ class AllPatcher:
                     self.arc_replacements[arc_name] = arc_path
 
     def patch_music_and_sound(self):
-        music_pack_list = [os.path.basename(f.path) for f in os.scandir(MUSIC_PACK_PATH) if f.is_dir()]
+        music_pack_list = [
+            os.path.basename(f.path) for f in os.scandir(MUSIC_PACK_PATH) if f.is_dir()
+        ]
 
         # Copy WZSound
         shutil.copy(WZSOUND_ACTUAL_PATH, WZSOUND_MODIFIED_PATH)
@@ -331,11 +341,15 @@ class AllPatcher:
     def copy_music_pack_to_modified(self, selected_pack):
         musiclist = yaml_load(RANDO_ROOT_PATH / "music.yaml")
         selected_pack_path = MUSIC_PACK_PATH / selected_pack
-        music_files = [os.path.basename(f.path) for f in os.scandir(selected_pack_path) if not f.is_dir()]
+        music_files = [
+            os.path.basename(f.path)
+            for f in os.scandir(selected_pack_path)
+            if not f.is_dir()
+        ]
         for music_file in music_files:
             # Tadtone song is also verified by musicrando.py
             if music_file in musiclist.keys() and music_file != TADTONE_SONG:
-                shutil.copy(selected_pack_path/music_file, WZS_MODIFIED_PATH)
+                shutil.copy(selected_pack_path / music_file, WZS_MODIFIED_PATH)
 
         wzsound_folder_arc_path = ARC_REPLACEMENTS_PATH / "WZSoundPatchInstructions"
         if os.path.exists(wzsound_folder_arc_path):
@@ -346,12 +360,22 @@ class AllPatcher:
             self.patch_wzsound(wzsound_folder_pack_path)
 
         if self.current_loftwing_model_pack_name != "Default":
-            loftwing_path = CUSTOM_MODELS_PATH / self.current_loftwing_model_pack_name / "Loftwing" / "WZSoundPatchInstructions"
+            loftwing_path = (
+                CUSTOM_MODELS_PATH
+                / self.current_loftwing_model_pack_name
+                / "Loftwing"
+                / "WZSoundPatchInstructions"
+            )
             if os.path.exists(loftwing_path):
                 self.patch_wzsound(loftwing_path)
 
         if self.current_player_model_pack_name != "Default":
-            player_path = CUSTOM_MODELS_PATH / self.current_player_model_pack_name / "Player" / "WZSoundPatchInstructions"
+            player_path = (
+                CUSTOM_MODELS_PATH
+                / self.current_player_model_pack_name
+                / "Player"
+                / "WZSoundPatchInstructions"
+            )
             if os.path.exists(player_path):
                 self.patch_wzsound(player_path)
 
@@ -363,11 +387,13 @@ class AllPatcher:
             if music_key != TADTONE_SONG:
                 possible_packs = []
                 for pack in music_pack_list:
-                    if os.path.exists(MUSIC_PACK_PATH/pack/music_key):
+                    if os.path.exists(MUSIC_PACK_PATH / pack / music_key):
                         possible_packs.append(pack)
                 random_pack = rng.choice(possible_packs + ["Vanilla"])
                 if random_pack != "Vanilla":
-                    shutil.copy(MUSIC_PACK_PATH/random_pack/music_key, WZS_MODIFIED_PATH)
+                    shutil.copy(
+                        MUSIC_PACK_PATH / random_pack / music_key, WZS_MODIFIED_PATH
+                    )
 
     def patch_wzsound(self, folder_path):
         with open(folder_path / "wzsound_instructions.patch", "r") as fp:
@@ -384,7 +410,6 @@ class AllPatcher:
                         with open(WZSOUND_MODIFIED_PATH, "r+b") as wzsound_fp:
                             wzsound_fp.seek(int(hex_location, 16))
                             wzsound_fp.write(data)
-
 
     def do_texture_recolour(
         self, arc_data: U8File, mask_folder_path: Path, color_data: dict

--- a/sslib/allpatch.py
+++ b/sslib/allpatch.py
@@ -35,6 +35,11 @@ DEFAULT_MODEL_DATA_PATH = RANDO_ROOT_PATH / "assets" / "default-link-data"
 CUSTOM_MODELS_PATH = Path("models")
 OARC_PATH = Path("oarc")
 
+WZSOUND_ACTUAL_PATH = RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
+WZSOUND_MODIFIED_PATH = RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "WZSound.brsar"
+WZS_ACTUAL_PATH = RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound" / "wzs"
+WZS_MODIFIED_PATH = RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "wzs"
+
 MASK_REGEX = re.compile(r"(.+(/|\\))*(?P<texName>.+)__(?P<colorGroupName>.+).png")
 
 
@@ -48,6 +53,7 @@ class AllPatcher:
         assets_path: Path,
         current_player_model_pack_name: str,
         current_loftwing_model_pack_name: str,
+        current_music_pack: str,
         copy_unmodified: bool = True,
     ):
         """
@@ -62,6 +68,7 @@ class AllPatcher:
         self.assets_path = assets_path
         self.current_player_model_pack_name = current_player_model_pack_name
         self.current_loftwing_model_pack_name = current_loftwing_model_pack_name
+        self.current_music_pack = current_music_pack
         self.copy_unmodified = copy_unmodified
         self.arc_replacements = {}
         if arc_replacement_path.is_dir():
@@ -294,6 +301,9 @@ class AllPatcher:
                         continue  # ignore arcs that get patched separately
                     self.arc_replacements[arc_name] = arc_path
 
+    def patch_music_and_sound(self):
+        shutil.copy(WZSOUND_ACTUAL_PATH, WZSOUND_MODIFIED_PATH)
+
     def do_texture_recolour(
         self, arc_data: U8File, mask_folder_path: Path, color_data: dict
     ) -> U8File:
@@ -340,6 +350,7 @@ class AllPatcher:
 
         self.patch_custom_models()
         self.patch_arc_replacements()
+        self.patch_music_and_sounds()
 
         # stages
         for stagepath in (self.actual_extract_path / "DATA" / "files" / "Stage").glob(

--- a/sslib/allpatch.py
+++ b/sslib/allpatch.py
@@ -44,6 +44,7 @@ WZS_ACTUAL_PATH = RANDO_ROOT_PATH / "actual-extract" / "DATA" / "files" / "Sound
 WZS_MODIFIED_PATH = RANDO_ROOT_PATH / "modified-extract" / "DATA" / "files" / "Sound" / "wzs"
 MUSIC_PACK_PATH = RANDO_ROOT_PATH / "music-packs"
 TADTONE_SONG = "F63D5DB51DE748A3729628C659397A49"
+ARC_REPLACEMENTS_PATH = RANDO_ROOT_PATH / "arc-replacements"
 
 MASK_REGEX = re.compile(r"(.+(/|\\))*(?P<texName>.+)__(?P<colorGroupName>.+).png")
 
@@ -335,6 +336,10 @@ class AllPatcher:
             # Tadtone song is also verified by musicrando.py
             if music_file in musiclist.keys() and music_file != TADTONE_SONG:
                 shutil.copy(selected_pack_path/music_file, WZS_MODIFIED_PATH)
+
+        wzsound_folder_arc_path = ARC_REPLACEMENTS_PATH / "WZSoundPatchInstructions"
+        if os.path.exists(wzsound_folder_arc_path):
+            self.patch_wzsound(wzsound_folder_arc_path)
 
         wzsound_folder_pack_path = selected_pack_path / "WZSoundPatchInstructions"
         if os.path.exists(wzsound_folder_pack_path):

--- a/sslib/bzs.py
+++ b/sslib/bzs.py
@@ -184,7 +184,7 @@ def buildBzs(root: ParsedBzs) -> bytes:
     pad = 32 - (len(data) % 32)
     if pad == 32:
         pad = 0
-    data += b"\xFF" * pad
+    data += b"\xff" * pad
     return data
 
 
@@ -197,7 +197,7 @@ def buildObj(objtype, objdata) -> (int, bytes):  # number of elements, bytes of 
         for typ, obj in objdata.items():
             count, data = buildObj(typ, obj)
             # pad to 4
-            pad = (4 - (len(data) % 4)) * b"\xFF"
+            pad = (4 - (len(data) % 4)) * b"\xff"
             if len(pad) == 4:
                 pad = b""
             headerbytes += struct.pack(
@@ -223,7 +223,7 @@ def buildObj(objtype, objdata) -> (int, bytes):  # number of elements, bytes of 
                 count, data = buildObj("V001", layer)
                 dataoffset = len(body) - len(headerbytes) + offset
                 # pad to 4
-                pad = (4 - (len(data) % 4)) * b"\xFF"
+                pad = (4 - (len(data) % 4)) * b"\xff"
                 if len(pad) == 4:
                     pad = b""
                 headerbytes += struct.pack(">hhi", count, -1, dataoffset)

--- a/sslib/msb.py
+++ b/sslib/msb.py
@@ -19,18 +19,18 @@ CONTROL_REPLACEMENTS = {
     "<g+<": "\x0e\x00\x03\x02\x07",  # green rupee green
     "<b+<": "\x0e\x00\x03\x02\x08",  # blue rupee blue
     "<r+<": "\x0e\x00\x03\x02\x09",  # red-white
-    "<s<": "\x0e\x00\x03\x02\x0A",  # silver
-    "<ye<": "\x0e\x00\x03\x02\x0B",  # gold rupee gold
-    "<blk<": "\x0e\x00\x03\x02\x0C",  # rupoor
-    ">>": "\x0e\x00\x03\x02\uFFFF",  # end color
+    "<s<": "\x0e\x00\x03\x02\x0a",  # silver
+    "<ye<": "\x0e\x00\x03\x02\x0b",  # gold rupee gold
+    "<blk<": "\x0e\x00\x03\x02\x0c",  # rupoor
+    ">>": "\x0e\x00\x03\x02\uffff",  # end color
     # start of option token, '-' means cancel (B) option
-    "[1]": "\x0e\x01\x00\x02\uFFFF",
+    "[1]": "\x0e\x01\x00\x02\uffff",
     "[2-]": "\x0e\x01\x01\x02\x00",
-    "[2]": "\x0e\x01\x01\x02\uFFFF",
+    "[2]": "\x0e\x01\x01\x02\uffff",
     "[3-]": "\x0e\x01\x02\x02\x00",
-    "[3]": "\x0e\x01\x02\x02\uFFFF",
+    "[3]": "\x0e\x01\x02\x02\uffff",
     "[4-]": "\x0e\x01\x03\x02\x00",
-    "[4]": "\x0e\x01\x03\x02\uFFFF",
+    "[4]": "\x0e\x01\x03\x02\uffff",
     "<numeric arg0>": "\x0e\x02\x03\x06\x00\x00\xcd",
     "<numeric arg1>": "\x0e\x02\x03\x06\x00\x01\xcd",
     "<numeric arg2>": "\x0e\x02\x03\x06\x00\x02\xcd",
@@ -51,10 +51,10 @@ def process_control_sequences(data: str) -> str:
 
 def parseMSB(data: bytes) -> ParsedMsb:
     parsed = OrderedDict()
-    if data[:10] == b"MsgFlwBn\xFE\xFF":
+    if data[:10] == b"MsgFlwBn\xfe\xff":
         parsed["type"] = "MsgFlwBn"
         assert data[10:16] == b"\x00\x00\x00\x03\x00\x02"
-    elif data[:10] == b"MsgStdBn\xFE\xFF":
+    elif data[:10] == b"MsgStdBn\xfe\xff":
         parsed["type"] = "MsgStdBn"
         assert data[10:16] == b"\x00\x00\x01\x03\x00\x03"
     else:
@@ -139,10 +139,10 @@ def parseMSB(data: bytes) -> ParsedMsb:
 
 def buildMSB(msb: ParsedMsb) -> bytes:
     if msb["type"] == "MsgFlwBn":
-        header = b"MsgFlwBn\xFE\xFF"
+        header = b"MsgFlwBn\xfe\xff"
         header += b"\x00\x00\x00\x03\x00\x02"
     elif msb["type"] == "MsgStdBn":
-        header = b"MsgStdBn\xFE\xFF"
+        header = b"MsgStdBn\xfe\xff"
         header += b"\x00\x00\x01\x03\x00\x03"
     else:
         raise Exception(f'Unsupported filetype: {msb["type"]}.')
@@ -211,7 +211,7 @@ def buildMSB(msb: ParsedMsb) -> bytes:
         total_body += seg_id.encode("ascii")
         total_body += struct.pack(">i", len(body)) + 8 * b"\x00"
         total_body += body
-        total_body += (-len(total_body) % 0x10) * b"\xAB"
+        total_body += (-len(total_body) % 0x10) * b"\xab"
     total_length = len(header) + len(total_body)
     header[0x12] = (total_length >> 24) & 0xFF
     header[0x13] = (total_length >> 16) & 0xFF


### PR DESCRIPTION
## What does this PR do?
- Allows for music packs to be added and dealt with by the program.
- Allows for music packs and model packs to have WZSound patch instructions.

## How do you test this changes?
- Add music packs and check if it replaces music
- Check to see if "Random Pack," "Random Songs from Packs" and "Don't Patch" work
- Check if sound effects defined by WZSound patch instruction folders properly work

## Notes
Just pushing to my fork (hopefully)
Ignore if this somehow pull requests to ssrando/ssrando

